### PR TITLE
update boston.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1102,7 +1102,7 @@ amny.com##.gridlove-sidebar
 amny.com##.gridlove-posts.row > div:has(.gridlove-inject)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/67#issuecomment-562770868
-boston.com##.site-container:style(margin-top: -100px !important;)
+boston.com##body:style(padding-top: 110px !important;)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/67#issuecomment-562770885
 bustle.com##.ka.gr.gq


### PR DESCRIPTION
Better mirror intended site design for `boston.com` so it doesn't break unexpectedly with other filter lists (e.g. Web Annoyances Ultralist)

Related: https://github.com/NanoAdblockerLab/NanoContrib/pull/67#issuecomment-562770868